### PR TITLE
Revert ""Fix" for cloud favorites and increased history size"

### DIFF
--- a/ReModCE/Components/AvatarFavoritesComponent.cs
+++ b/ReModCE/Components/AvatarFavoritesComponent.cs
@@ -125,8 +125,7 @@ namespace ReModCE.Components
             _searchedAvatarList = new ReAvatarList("ReModCE Search", this);
 
             _favoriteAvatarList = new ReAvatarList("ReModCE Favorites", this, false);
-            // - commented out as a quick fix, because this field is not neccessary and breaks the ui initialization on the current vrchat update as of 21.04.2022
-            //_favoriteAvatarList.AvatarPedestal.field_Internal_Action_3_String_GameObject_AvatarPerformanceStats_0 = new Action<string, GameObject, AvatarPerformanceStats>(OnAvatarInstantiated);
+            _favoriteAvatarList.AvatarPedestal.field_Internal_Action_3_String_GameObject_AvatarPerformanceStats_0 = new Action<string, GameObject, AvatarPerformanceStats>(OnAvatarInstantiated);
             _favoriteAvatarList.OnEnable += () =>
             {
                 // make sure it stays off if it should be off.
@@ -479,16 +478,6 @@ namespace ReModCE.Components
 
         private void FetchAvatars()
         {
-            // offline edit # start
-            if (File.Exists("UserData/ReModCE/avatars.bin"))
-            {
-                _savedAvatars = BinaryGZipSerializer.Deserialize("UserData/ReModCE/avatars.bin") as List<ReAvatar>;
-            }
-            else
-            {
-                _savedAvatars = new List<ReAvatar>();
-            }
-            /*
             SendAvatarRequest(HttpMethod.Get, avatarResponse =>
             {
                 if (!avatarResponse.IsSuccessStatusCode)
@@ -507,8 +496,6 @@ namespace ReModCE.Components
                     _savedAvatars = JsonConvert.DeserializeObject<List<ReAvatar>>(t.Result);
                 });
             });
-            */
-            // offline edit # end
         }
 
         private static IEnumerator ShowAlertDelayed(string message, float seconds = 0.5f)
@@ -538,8 +525,6 @@ namespace ReModCE.Components
             
             var hasFavorited = HasAvatarFavorited(apiAvatar.id);
             
-            // offline edit # start
-            /*
             SendAvatarRequest(hasFavorited ? HttpMethod.Delete : HttpMethod.Put, favResponse =>
             {
                 if (!favResponse.IsSuccessStatusCode)
@@ -563,7 +548,6 @@ namespace ReModCE.Components
                 }
             }, new ReAvatar(apiAvatar));
 
-            */
             if (_favoriteAvatarList.AvatarPedestal.field_Internal_ApiAvatar_0.id == apiAvatar.id)
             {
                 if (!HasAvatarFavorited(apiAvatar.id))
@@ -577,9 +561,6 @@ namespace ReModCE.Components
                     _favoriteButton.Text = "Favorite";
                 }
             }
-            // offline edit # save to file
-            BinaryGZipSerializer.Serialize(_savedAvatars, "UserData/ReModCE/avatars.bin");
-            // offline edit # end
 
             _favoriteAvatarList.RefreshAvatars();
         }

--- a/ReModCE/Components/AvatarHistoryComponent.cs
+++ b/ReModCE/Components/AvatarHistoryComponent.cs
@@ -151,7 +151,7 @@ namespace ReModCE.Components
 
             _recentAvatars.Insert(0, new ReAvatar(avatar));
 
-            if (_recentAvatars.Count > 250)
+            if (_recentAvatars.Count > 25)
             {
                 _recentAvatars.Remove(_recentAvatars.Last());
             }


### PR DESCRIPTION
Actually upon further thought I'm going to revert this because:
* It creates a whole new favorites list and doesn't transfer over the cloud favorites
* It saves the favorites in a format unreadable to a text editor (which may be necessary to extract favorites if the mod ever breaks)
* The favorites can't be accessed from the vanilla ReModCE in case this version breaks

I appreciate the effort you put into these changes but the goal of this project is to stay as close as possible to ReModCE while just unlocking stuff to make maintenance easier. I wish you the best with your fork.